### PR TITLE
Feature/add book production status

### DIFF
--- a/app/controllers/BookController.php
+++ b/app/controllers/BookController.php
@@ -483,4 +483,12 @@ class BookController extends Controller{
     return "failed";
   }
 
+  public function deleteProd()
+  {
+    $bpId = Input::get("prod_id", null);
+    $bp = BookProd::find($bpId);
+    $bp->delete();
+    return "success";
+  }
+
 }

--- a/app/controllers/BookController.php
+++ b/app/controllers/BookController.php
@@ -456,12 +456,9 @@ class BookController extends Controller{
   public function postProdedit()
   {
     $bpId = Input::get("prod_id", null);
-    $bp = BookProd::find();
-    $bp->book_id=Input::get("book_id", null);
-    $bp->media_type=Input::get("media_type", null);
-    $bp->action=Input::get("action", null);
-    $bp->actioner=Input::get("actioner", null);
-
+    $bp = BookProd::find($bpId);
+    $bp->action = Input::get("action");
+    $bp->actioner = Input::get("actioner", null);
     if(Input::get('act_date',null)){
         $dateTmp = date_create_from_format('d/m/Y', Input::get('act_date',null));
         $bp->act_date=date_format($dateTmp, 'Y-m-d H:i:s');

--- a/app/controllers/BookController.php
+++ b/app/controllers/BookController.php
@@ -452,6 +452,16 @@ class BookController extends Controller{
         //var_dump($bp);
     return $bp;
   }
+
+  public function getLastProdStatus()
+  {
+    $lastProd = BookProd::where('book_id', '=', Input::get('book_id'))
+                ->where('media_type', '=', Input::get('media_type'))->get();
+    $lastProd = $lastProd->last();
+    if(!count($lastProd))
+        return array('action_status' => -1, 'finish_date' => 1);
+    return array('action_status' => $lastProd->action, 'finish_date' => $lastProd->finish_date);
+  }
   
   public function postProdedit()
   {

--- a/app/controllers/BookController.php
+++ b/app/controllers/BookController.php
@@ -174,8 +174,7 @@ class BookController extends Controller{
         $item->borrower = Member::find($borrow->member_id)->name;
     }
 
-
-    $prod = $bookEloquent->prod;
+    $prod = $this->addLastStatusToProd($bookEloquent->prod);
 
     $arrOfdata['field']=$field;
     $arrOfdata['book']=$book;
@@ -448,8 +447,7 @@ class BookController extends Controller{
   public function getProd($id)
   {
     $book = Book::find($id);
-    $bp = $book->prod;
-        //var_dump($bp);
+    $bp = $this->addLastStatusToProd($book->prod);
     return $bp;
   }
 
@@ -501,4 +499,19 @@ class BookController extends Controller{
     return "success";
   }
 
+  public function addLastStatusToProd($prod)
+  {
+    $lastAction = array(-1, -1, -1, -1, -1);
+    foreach ($prod as $key => $item) {
+        if($item->action > $lastAction[$item->media_type])
+            $lastAction[$item->media_type] = $item->action;
+    }
+    foreach ($prod as $key => $item) {
+        if($item->action == $lastAction[$item->media_type])
+            $item->isLastStatus = true;
+        else
+            $item->isLastStatus = false;
+    }
+    return $prod;
+  }
 }

--- a/app/routes.php
+++ b/app/routes.php
@@ -20,6 +20,7 @@ Route::group(array('before' => 'auth'), function() {
     Route::post('edit', 'BookController@postEdit');
 
     Route::group(array('prefix' => 'prod/'), function(){
+      Route::post('get_status', 'BookController@getLastProdStatus');
       Route::post('add', 'BookController@postProdAdd');
       Route::post('edit', 'BookController@postProdedit');
       Route::post('delete', 'BookController@deleteProd');

--- a/app/routes.php
+++ b/app/routes.php
@@ -22,6 +22,7 @@ Route::group(array('before' => 'auth'), function() {
     Route::group(array('prefix' => 'prod/'), function(){
       Route::post('add', 'BookController@postProdAdd');
       Route::post('edit', 'BookController@postProdedit');
+      Route::post('delete', 'BookController@deleteProd');
       Route::get('view', 'BookController@getProd');
 
     });

--- a/app/views/library/book/part/prod.blade.php
+++ b/app/views/library/book/part/prod.blade.php
@@ -4,17 +4,17 @@
     <div class="col-xs-12">
       <div class="panel panel-info">
         <div class="panel-heading">
-          <div class="panel-title" style="">
+          <div class="panel-title">
             @if ($i==0)
-            เบรลล์ <a class="pull-right" onclick="addProd(0)"><h3 class="label label-primary add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิตเบรลล์</h3></a>
+            เบรลล์ <a class="pull-right" onclick="addProd(0)"><h3 class="label label-primary add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิต</h3></a>
             @elseif ($i==1)
-            คาสเซ็ท <a class="pull-right" onclick="addProd(1)"><h3 class="label label-primary add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิตคาสเซ็ท</h3></a>
+            คาสเซ็ท <a class="pull-right" onclick="addProd(1)"><h3 class="label label-primary add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิต</h3></a>
             @elseif ($i==2)
-            เดซี่ <a class="pull-right" onclick="addProd(2)"><h3 class="label label-primary add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิตเดซี่</h3></a>
+            เดซี่ <a class="pull-right" onclick="addProd(2)"><h3 class="label label-primary add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิต</h3></a>
             @elseif ($i==3)
-            CD <a class="pull-right" onclick="addProd(3)"><h3 class="label label-primary add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิต CD</h3></a>
+            CD <a class="pull-right" onclick="addProd(3)"><h3 class="label label-primary add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิต</h3></a>
             @elseif ($i==4)
-            DVD <a class="pull-right" onclick="addProd(4)"><h3 class="label label-primary add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิต DVD</h3></a>
+            DVD <a class="pull-right" onclick="addProd(4)"><h3 class="label label-primary add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิต</h3></a>
             @endif
           </div>
         </div>
@@ -31,7 +31,7 @@
             <tbody>
               @foreach ($prod as $data)
               @if ($data["media_type"]==$i)
-              <tr data-prodId="{{$data["id"]}}" >
+              <tr data-prodId="{{$data["id"]}}" class="hover">
                 <td data-action="{{$data["action"]}}" onclick="prodEditShow(this)">
                   @if($i == 0)
                     @if ($data["action"]==0)

--- a/app/views/library/book/part/prod.blade.php
+++ b/app/views/library/book/part/prod.blade.php
@@ -6,15 +6,15 @@
         <div class="panel-heading">
           <div class="panel-title" style="">
             @if ($i==0)
-            เบรลล์ <a class="pull-right" onclick="addProd(0)"><h3 class="label label-warning add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิตเบรลล์</h3></a>
+            เบรลล์ <a class="pull-right" onclick="addProd(0)"><h3 class="label label-primary add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิตเบรลล์</h3></a>
             @elseif ($i==1)
-            คาสเซ็ท <a class="pull-right" onclick="addProd(1)"><h3 class="label label-warning add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิตคาสเซ็ท</h3></a>
+            คาสเซ็ท <a class="pull-right" onclick="addProd(1)"><h3 class="label label-primary add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิตคาสเซ็ท</h3></a>
             @elseif ($i==2)
-            เดซี่ <a class="pull-right" onclick="addProd(2)"><h3 class="label label-warning add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิตเดซี่</h3></a>
+            เดซี่ <a class="pull-right" onclick="addProd(2)"><h3 class="label label-primary add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิตเดซี่</h3></a>
             @elseif ($i==3)
-            CD <a class="pull-right" onclick="addProd(3)"><h3 class="label label-warning add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิต CD</h3></a>
+            CD <a class="pull-right" onclick="addProd(3)"><h3 class="label label-primary add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิต CD</h3></a>
             @elseif ($i==4)
-            DVD <a class="pull-right" onclick="addProd(4)"><h3 class="label label-warning add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิต DVD</h3></a>
+            DVD <a class="pull-right" onclick="addProd(4)"><h3 class="label label-primary add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิต DVD</h3></a>
             @endif
           </div>
         </div>

--- a/app/views/library/book/part/prod.blade.php
+++ b/app/views/library/book/part/prod.blade.php
@@ -35,14 +35,24 @@
               @if ($data["media_type"]==$i)
               <tr data-prodId="{{$data["id"]}}" >
                 <td data-action="{{$data["action"]}}" onclick="prodEditShow(this)">
-                  @if ($data["action"]==0)
-                    อ่าน
-                  @elseif ($data["action"]==1)
-                    ทำต้นฉบับ
-                  @elseif ($data["action"]==2)
-                    ทำกล่อง
-                  @elseif ($data["action"]==3)
-                    ส่งตรวจ
+                  @if($i == 0)
+                    @if ($data["action"]==0)
+                      พิมพ์ต้นฉบับ
+                    @elseif ($data["action"]==1)
+                      ตรวจตาดี
+                    @elseif ($data["action"]==2)
+                      ตรวจบรู๊ฟเบรลล์
+                    @endif
+                  @else
+                    @if ($data["action"]==0)
+                      อ่าน
+                    @elseif ($data["action"]==1)
+                      ทำต้นฉบับ
+                    @elseif ($data["action"]==2)
+                      ทำกล่อง
+                    @elseif ($data["action"]==3)
+                      ส่งตรวจ
+                    @endif
                   @endif
                 </td>
                 <td data-actioner="{{$data["actioner"]}}" onclick="prodEditShow(this)">{{$data["actioner"]}}</td>
@@ -59,7 +69,11 @@
                     {{date_format(date_create($data["finish_date"]), 'd/m/Y')}}
                   @endif
                 </td>
-                <td onclick="prodDelete(this)"><button class="btn btn-danger">ลบ</button></td>
+                <td><button onclick="prodEditShowOnButton(this)" class="btn btn-success">แก้ไข</button>
+                @if($data["isLastStatus"])
+                  <button onclick="prodDelete(this)" class="btn btn-danger">ลบ</button>
+                @endif
+                </td>
               </tr>
               @endif
               @endforeach
@@ -89,7 +103,8 @@
             <div class="form-group">
               <label class="col-sm-2 control-label">*สถานะ</label>
               <div class="col-sm-10">
-                <select name="" id="prod_edit_action" class="form-control" required="required">
+                <input type="text" class="form-control" id="prod_edit_action_text" disabled>
+                <select name="" id="prod_edit_action" class="form-control" required="required" style="display: none">
                   <option value="">เลือกสถานะ</option>
                   <option value="0">อ่าน</option>
                   <option value="1">ทำต้นฉบับ</option>

--- a/app/views/library/book/part/prod.blade.php
+++ b/app/views/library/book/part/prod.blade.php
@@ -121,7 +121,7 @@
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">ปิด</button>
-        <button type="button" class="btn btn-primary" onclick="prodEditAjax()">Save changes</button>
+        <button type="button" class="btn btn-primary" onclick="prodEditAjax()">บันทึก</button>
       </div>
     </div>
   </div>

--- a/app/views/library/book/part/prod.blade.php
+++ b/app/views/library/book/part/prod.blade.php
@@ -33,8 +33,8 @@
             <tbody>
               @foreach ($prod as $data)
               @if ($data["media_type"]==$i)
-              <tr data-prodId="{{$data["id"]}}" onclick="prodEditShow(this)">
-                <td data-action="{{$data["action"]}}">
+              <tr data-prodId="{{$data["id"]}}" >
+                <td data-action="{{$data["action"]}}" onclick="prodEditShow(this)">
                   @if ($data["action"]==0)
                     อ่าน
                   @elseif ($data["action"]==1)
@@ -45,20 +45,21 @@
                     ส่งตรวจ
                   @endif
                 </td>
-                <td data-actioner="{{$data["actioner"]}}">{{$data["actioner"]}}</td>
-                <td class="prodEdit-act_date">@if ($data["act_date"] == "0000-00-00 00:00:00")
+                <td data-actioner="{{$data["actioner"]}}" onclick="prodEditShow(this)">{{$data["actioner"]}}</td>
+                <td class="prodEdit-act_date" onclick="prodEditShow(this)">@if ($data["act_date"] == "0000-00-00 00:00:00")
                   ยังไม่ได้ระบุ
                 @else
                   {{date_format(date_create($data["act_date"]), 'd/m/Y')}}
                 @endif
                 </td>
-                <td class="prodEdit-act_date" data-finish-date="{{$data["finish_date"]}}">
+                <td class="prodEdit-act_date" data-finish-date="{{$data["finish_date"]}}" onclick="prodEditShow(this)">
                   @if ($data["finish_date"] == "0000-00-00 00:00:00"||$data["finish_date"] == null)
                     ยังไม่ได้ระบุ
                   @else
                     {{date_format(date_create($data["finish_date"]), 'd/m/Y')}}
                   @endif
                 </td>
+                <td onclick="prodDelete(this)"><button class="btn btn-danger">ลบ</button></td>
               </tr>
               @endif
               @endforeach

--- a/app/views/library/book/part/prod.blade.php
+++ b/app/views/library/book/part/prod.blade.php
@@ -80,6 +80,11 @@
         <h4 class="modal-title">แก้ไขสถานะการผลิต</h4>
       </div>
       <div class="modal-body">
+        <div class="row">
+          <div class="alert alert-danger" id='prod-edit-noti' hidden>
+            กรุณาใส่ข้อมูลที่มี * ให้ถูกต้อง และครบถ้วน
+          </div>
+        </div>
         <div class="row" id="prod-edit-body">
             <div class="form-group">
               <label class="col-sm-2 control-label">*สถานะ</label>
@@ -115,7 +120,7 @@
         <input id="prod_edit_id" type="hidden" value="">
       </div>
       <div class="modal-footer">
-        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+        <button type="button" class="btn btn-default" data-dismiss="modal">ปิด</button>
         <button type="button" class="btn btn-primary" onclick="prodEditAjax()">Save changes</button>
       </div>
     </div>

--- a/app/views/library/book/part/prod.blade.php
+++ b/app/views/library/book/part/prod.blade.php
@@ -46,17 +46,17 @@
                   @endif
                 </td>
                 <td data-actioner="{{$data["actioner"]}}">{{$data["actioner"]}}</td>
-                <td>@if ($data["act_date"] == "0000-00-00 00:00:00")
+                <td class="prodEdit-act_date">@if ($data["act_date"] == "0000-00-00 00:00:00")
                   ยังไม่ได้ระบุ
                 @else
-                  {{date_format(date_create($data["act_date"]), 'd-m-Y')}}
+                  {{date_format(date_create($data["act_date"]), 'd/m/Y')}}
                 @endif
                 </td>
-                <td data-finish-date="{{$data["finish_date"]}}">
+                <td class="prodEdit-act_date" data-finish-date="{{$data["finish_date"]}}">
                   @if ($data["finish_date"] == "0000-00-00 00:00:00"||$data["finish_date"] == null)
                     ยังไม่ได้ระบุ
                   @else
-                    {{date_format(date_create($data["finish_date"]), 'd-m-Y')}}
+                    {{date_format(date_create($data["finish_date"]), 'd/m/Y')}}
                   @endif
                 </td>
               </tr>
@@ -76,23 +76,10 @@
     <div class="modal-content">
       <div class="modal-header">
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-        <h4 class="modal-title">Prod Edit</h4>
+        <h4 class="modal-title">แก้ไขสถานะการผลิต</h4>
       </div>
       <div class="modal-body">
         <div class="row" id="prod-edit-body">
-            <div class="form-group">
-              <label class="col-sm-2 control-label">*สื่อ</label>
-              <div class="col-sm-10">
-                <select name="" id="prod_edit_media_type" class="form-control" required="required">
-                  <option value="">เลือกสื่อ</option>
-                  <option value="0">เบรลล์</option>
-                  <option value="1">เทปคาสเซ็ท</option>
-                  <option value="2">เดซี่</option>
-                  <option value="3">CD</option>
-                  <option value="4">DVD</option>
-                </select>
-              </div>
-            </div>
             <div class="form-group">
               <label class="col-sm-2 control-label">*สถานะ</label>
               <div class="col-sm-10">
@@ -124,10 +111,11 @@
               </div>
             </div>
         </div>
+        <input id="prod_edit_id" type="hidden" value="">
       </div>
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
-        <button type="button" class="btn btn-primary">Save changes</button>
+        <button type="button" class="btn btn-primary" onclick="prodEditAjax()">Save changes</button>
       </div>
     </div>
   </div>

--- a/app/views/library/book/part/prod.blade.php
+++ b/app/views/library/book/part/prod.blade.php
@@ -1,24 +1,22 @@
 <div role="tabpanel" class="tab-pane" >
   <div>
-  <h3>สถานะการผลิต<p class="btn btn-sm btn-warning pull-right" data-toggle="modal" data-target="#addProd">เพิ่มสถานะการผลิต</p>
-  </h3>
       @for ($i = 0; $i < 5; $i++)
     <div class="col-xs-12">
       <div class="panel panel-info">
         <div class="panel-heading">
-          <h3 class="panel-title">
+          <div class="panel-title" style="">
             @if ($i==0)
-            เบรลล์
+            เบรลล์ <a class="pull-right" onclick="addProd(0)"><h3 class="label label-warning add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิตเบรลล์</h3></a>
             @elseif ($i==1)
-            คาสเซ็ท
+            คาสเซ็ท <a class="pull-right" onclick="addProd(1)"><h3 class="label label-warning add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิตคาสเซ็ท</h3></a>
             @elseif ($i==2)
-            เดซี่
+            เดซี่ <a class="pull-right" onclick="addProd(2)"><h3 class="label label-warning add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิตเดซี่</h3></a>
             @elseif ($i==3)
-            CD
+            CD <a class="pull-right" onclick="addProd(3)"><h3 class="label label-warning add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิต CD</h3></a>
             @elseif ($i==4)
-            DVD
+            DVD <a class="pull-right" onclick="addProd(4)"><h3 class="label label-warning add-media-prod"><i class="fa fa-plus fa-2"></i> เพิ่มสถานะการผลิต DVD</h3></a>
             @endif
-          </h3>
+          </div>
         </div>
         <div class="panel-body">
           <table class="table table-hover">

--- a/app/views/library/book/view.blade.php
+++ b/app/views/library/book/view.blade.php
@@ -490,10 +490,10 @@ function confirmation(link) {
 
     function prodEditShow(prodObj) {
       // Append hidden field for prodId
-      $('#prod_edit_action option[value=' + $(prodObj).children().eq(0).attr("data-action") + ']').attr('selected', 'selected');
-      $('#prod_edit_actioner').val($(prodObj).children().eq(1).attr("data-actioner"));
-      $('#prod_edit_act_date').val($(prodObj).children().eq(2).text().trim());
-      $('#prod_edit_finish_date').val($(prodObj).children().eq(3).text().trim());
+      $('#prod_edit_action option[value=' + $(prodObj).parent().children().eq(0).attr("data-action") + ']').attr('selected', 'selected');
+      $('#prod_edit_actioner').val($(prodObj).parent().children().eq(1).attr("data-actioner"));
+      $('#prod_edit_act_date').val($(prodObj).parent().children().eq(2).text().trim());
+      $('#prod_edit_finish_date').val($(prodObj).parent().children().eq(3).text().trim());
       console.log($(prodObj).children()[1]);
       console.log($(prodObj).children()[2]);
       console.log($(prodObj).children()[3]);
@@ -525,6 +525,19 @@ function confirmation(link) {
 
         }
       });
+    }
+
+    function prodDelete(prodObj) {
+      if(confirm("คุณต้องการลบรายการนี้ใช่หรือไม่")) {
+        $.ajax({
+          type: "POST",
+          url: "/book/{{ $book['id'] }}/prod/delete",
+          data: {prod_id: $(prodObj).parent().attr('data-prodId')}
+        }).done(function(data) {
+          if(data == "success")
+            $(prodObj).parent().remove();
+        }); 
+      }
     }
   </script>
 

--- a/app/views/library/book/view.blade.php
+++ b/app/views/library/book/view.blade.php
@@ -228,9 +228,10 @@
         </div>
         <div class="row" id="addProdBody">
             <div class="form-group">
-              <label class="col-sm-2 control-label">*สื่อ</label>
+              <label class="col-sm-2 control-label">ประเภทสื่อ</label>
               <div class="col-sm-10">
-                <select name="" id="prod_media_type" class="form-control" required="required">
+                <input type="text" class="form-control" id="prod_media_type_text" disabled="disabled">
+                <select name="" id="prod_media_type" class="form-control" required="required" style="display: none">
                   <option value="">เลือกสื่อ</option>
                   <option value="0">เบรลล์</option>
                   <option value="1">เทปคาสเซ็ท</option>
@@ -507,7 +508,7 @@ function confirmation(link) {
     });
   });
 
-  $('#prod_media_type').change(function() {
+  function addProdModal() {
     var media_type = $('#prod_media_type').val();
     $("#prod_media_type option[value='']").remove();
     enableProdText();
@@ -527,7 +528,7 @@ function confirmation(link) {
           $('#prod-noti3').slideDown(300);
         }
       });
-    });
+    }
 
   function changeProdAction(media_type) {
     console.log(media_type);
@@ -567,6 +568,14 @@ function confirmation(link) {
     $('#prod-noti1').hide();
     $('#prod-noti2').hide();
     $('#prod-noti3').hide();
+  }
+
+  function addProd(media_type) {
+    changeProdAction(media_type);
+    $('#prod_media_type option[value="' + media_type + '"]').attr('selected', 'true');
+    $('#prod_media_type_text').val($('#prod_media_type option[value="' + media_type + '"]').text().trim());
+    $('#addProd').modal('show');
+    addProdModal();
   }
 
   function postProd(){

--- a/app/views/library/book/view.blade.php
+++ b/app/views/library/book/view.blade.php
@@ -123,9 +123,9 @@
           <div class="form-group">
             <label class="sr-only" for="exampleInputAmount">Amount (in dollars)</label>
             <div class="input-group">
-              <div class="input-group-addon">สื่อชิ้นนี้มี</div>
+              <div class="input-group-addon" id="add-media-prefix">จำนวนแผ่น</div>
               <input type="number" class="form-control" id="amount" min=1 value="1">
-              <div class="input-group-addon">ชิ้นย่อย</div>
+              <div class="input-group-addon" id="add-media-suffix">แผ่น</div>
               <div class="input-group-addon">ความยาว</div>
               <input type="number" class="form-control" id="length" min=1 value="1">
               <div class="input-group-addon">นาที</div>
@@ -184,7 +184,7 @@
         <h4 class="modal-title">ข้อความ</h4>
       </div>
       <div class="modal-body">
-        เพิ่มสื่อสำเร็จ
+        การทำรายการสำเร็จ
       </div>
     </div>
   </div>
@@ -348,33 +348,44 @@ $("table").on("click", "tr.table-body", function() {
   media_id = $(this).children('#media-id').text();
   $('#media-title-head').text('แก้ไขรายละเอียด' + media_type[tabClicked]);
   if(tabClicked == "braille") {
-    original_part = $(this).children('.braille-part').text();
+    original_part = $(this).children('#braille-part').text();
     $('#test').html('<div class="col-md-2">จำนวนหน้า</div>\
                      <div class="col-md-4">\
                      <input type="number" class="form-control" id="edit-page-braille" min=1 value="">\
-                     </div><br><br><br>\
+                     </div>\
+                     <div class="col-md-2">หน้า</div><br><br><br>\
                      <div class="col-md-2">จำนวนตอน</div>\
                      <div class="col-md-4">\
                      <input type="number" class="form-control" id="edit-part-braille" min=1 value="">\
-                     </div><br><br><br>\
+                     </div>\
+                     <div class="col-md-2">ตอน</div><br><br><br>\
                      <div class="col-md-2">ผู้ตรวจสอบ</div>\
                      <div class="col-md-6"><input type="text" class="form-control" id="edit-examiner-braille"value="">\
                      </div>');
-    $('#edit-page-braille').attr('value', $(this).children('.braille-page').text());
+    console.log("test" +$(this).children('.braille-page').text());
+    $('#edit-page-braille').attr('value', $(this).children('#braille-page').text());
     $('#edit-part-braille').attr('value', original_part);
-    $('#edit-examiner-braille').attr('value', $(this).children('.braille-examiner').text());
+    $('#edit-examiner-braille').attr('value', $(this).children('#braille-examiner').text());
   }
   else {
     original_part = $(this).children('#media-part').text();
-    $('#test').html('<div class="col-md-3">ความยาว</div>\
-                     <div class="col-md-3"><input type="number" class="form-control" id="edit-length" value="">\
-                     </div>\
-                     <div class="col-md-2">นาที</div>\
-                     <br><br><br>\
-                     <div class="col-md-3">จำนวนชิ้นย่อย</div>\
+    $('#test').html('<div class="col-md-3" id="amount-prefix">จำนวนแผ่น</div>\
                      <div class="col-md-3"><input type="number" class="form-control" id="edit-part" value="">\
                      </div>\
-                     <div class="col-md-2">ชิ้น</div>');
+                     <div class="col-md-2" id="amount-suffix">แผ่น</div>\
+                     <br><br><br>\
+                      <div class="col-md-3">ความยาว</div>\
+                     <div class="col-md-3"><input type="number" class="form-control" id="edit-length" value="">\
+                     </div>\
+                     <div class="col-md-2">นาที</div>');
+    if(tabClicked == "daisy") {
+      $('#amount-prefix').text("จำนวนชิ้น");
+      $('#amount-suffix').text("ชิ้น");
+    }
+    else if(tabClicked == "cassette") {
+      $('#amount-prefix').text("จำนวนตลับ");
+      $('#amount-suffix').text("ตลับ");
+    }
 
     $('#edit-length').attr('value', $(this).children('#media-length').text());
     $('#edit-part').attr('value', original_part);
@@ -404,9 +415,9 @@ $('body').on('click', '#send-data', function() {
     //console.log(data);
     //console.log('#' + tabClicked + '-' + media_id);
     if(tabClicked == "braille") {
-      $('#' + tabClicked + '-' + media_id).children('.braille-page').text(page_amount);
-      $('#' + tabClicked + '-' + media_id).children('.braille-examiner').text(examiner);
-      $('#' + tabClicked + '-' + media_id).children('.braille-part').text(part_amount);
+      $('#' + tabClicked + '-' + media_id).children('#braille-page').text(page_amount);
+      $('#' + tabClicked + '-' + media_id).children('#braille-examiner').text(examiner);
+      $('#' + tabClicked + '-' + media_id).children('#braille-part').text(part_amount);
     }
     else {
       $('#' + tabClicked + '-' + media_id).children('#media-length').text(length);
@@ -426,11 +437,20 @@ $(function() {
   function verifyAdding(media_type) {
     var data = getLastProdStatus(media_type);
     data.success(function(data) {
-        if(data['finish_date'] && (data['action_status'] == 3)) {
+        if(data['finish_date'] && (media_type && (data['action_status'] == 3) || media_type == 0 && (data['action_status'] == 2))) {
           if(!media_type)
             $('#addBraille').modal('show');
-          else
+          else {
+            if(media_type == 1) {
+              $('#add-media-prefix').text('จำนวนตลับ');
+              $('#add-media-suffix').text('ตลับ');
+            }
+            else if(media_type == 2) {
+              $('#add-media-prefix').text('จำนวนชิ้น');
+              $('#add-media-suffix').text('ชิ้น');
+            }
             $('#add').modal('show');
+          }
         }
         else
           $('#prod-notify').modal('show');

--- a/app/views/library/book/view.blade.php
+++ b/app/views/library/book/view.blade.php
@@ -11,7 +11,7 @@
   </div>
   <ul class="nav nav-tabs nav-justified" role="tablist">
     <li role="presentation" class="active"><a href="#detail" role="tab" data-toggle="tab">ข้อมูล</a></li>
-    <li role="presentation"><a href="#prod" role="prod" data-toggle="tab" >สถานะการผลิต</a></li>
+    <li role="presentation"><a href="#prod" role="prod" data-toggle="tab" onClick="tabSelect(this)">สถานะการผลิต</a></li>
     <li role="presentation"><a href="#braille" role="braille" data-toggle="tab" onClick="tabSelect(this)">เบรลล์</a></li>
     <li role="presentation"><a href="#cassette" role="cassette" data-toggle="tab" onClick="tabSelect(this)">เทปคาสเซ็ท</a></li>
     <li role="presentation"><a href="#daisy" role="daisy" data-toggle="tab" onClick="tabSelect(this)">เดซี่</a></li>
@@ -72,35 +72,35 @@
     <div role="tabpanel" class="tab-pane" id="braille">
       <div class="row" >
         @include('library.book.part.braille',array('braille'=>$braille,'bid'=>$book['id']))
-        <button  class="pull-right addButton btn btn-lg btn-success" data-toggle="modal" data-target="#addBraille">เพิ่มเบรลล์</button>
+        <button  class="pull-right addButton btn btn-lg btn-success" onclick="verifyAdding(0)">เพิ่มเบรลล์</button>
       </div>
     </div>
 
     <div role="tabpanel" class="tab-pane" id="cassette">
       <div class="row" >
         @include('library.book.part.cassette',array('cassette'=>$cassette,'bid'=>$book['id']))
-        <button class="pull-right addButton btn btn-lg btn-success" data-toggle="modal" data-target="#add">เพิ่มคาสเซ็ท</button>
+        <button class="pull-right addButton btn btn-lg btn-success" onclick="verifyAdding(1)">เพิ่มคาสเซ็ท</button>
       </div>
     </div>
 
     <div role="tabpanel" class="tab-pane" id="daisy">
       <div class="row">
         @include('library.book.part.daisy',array('daisy'=>$daisy,'bid'=>$book['id']))
-        <button class="pull-right addButton btn btn-lg btn-success" data-toggle="modal" data-target="#add">เพิ่มเดซี่</button>
+        <button class="pull-right addButton btn btn-lg btn-success" onclick="verifyAdding(2)">เพิ่มเดซี่</button>
       </div>
     </div>
 
     <div role="tabpanel" class="tab-pane" id="cd">
       <div class="row">
         @include('library.book.part.cd',array('cd'=>$cd,'bid'=>$book['id']))
-        <button class="pull-right addButton btn btn-lg btn-success" data-toggle="modal" data-target="#add">เพิ่มCD</button>
+        <button class="pull-right addButton btn btn-lg btn-success" onclick="verifyAdding(3)">เพิ่มCD</button>
       </div>
     </div>
 
     <div role="tabpanel" class="tab-pane" id="dvd">
       <div class="row">
         @include('library.book.part.dvd',array('dvd'=>$dvd,'bid'=>$book['id']))
-        <button class="pull-right addButton btn btn-lg btn-success" data-toggle="modal" data-target="#add">เพิ่มDVD</button>
+        <button class="pull-right addButton btn btn-lg btn-success" onclick="verifyAdding(4)">เพิ่มDVD</button>
       </div>
     </div>
 
@@ -190,6 +190,23 @@
   </div>
 </div>
 
+<div class="modal fade" id="prod-notify">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title">ไม่สามารถเพิ่มสื่อได้</h4>
+      </div>
+      <div class="modal-body">
+        กระบวนการผลิตยังไม่เสร็จสมบูรณ์ โปรดตรวจสอบสถานะการผลิต
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal">ปิด</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <div class="modal fade" id="addProd">
   <div class="modal-dialog">
     <div class="modal-content">
@@ -206,7 +223,7 @@
             กรุณาใส่ข้อมูลที่มี * ให้ถูกต้อง และครบถ้วน
           </div>
           <div class="alert alert-danger" id='prod-noti3' hidden>
-            ไม่สามารถเพิ่มสถานะได้ เนื่องจากเสร็จสิ้นกระบวนการทำต้นฉบับแล้ว
+            ไม่สามารถเพิ่มสถานะได้ เนื่องจากเสร็จสิ้นกระบวนการผลิตแล้ว
           </div>
         </div>
         <div class="row" id="addProdBody">
@@ -311,6 +328,7 @@ function tabSelect(tab){
   //console.log(tab);
   //console.log(tab.getAttribute('role').toLowerCase());
   tabClicked = tab.getAttribute('role').toLowerCase();
+  console.log(tabClicked);
   document.location.href = document.location.href.substring(0, tabClicked.lastIndexOf('#') + 1)+'#'+tabClicked;
   window.scrollTo(0, 0);
   if(tabClicked == "braille"){
@@ -404,6 +422,19 @@ $(function() {
   hash && $('ul.nav a[href="' + hash + '"]').tab('show');
 });
 
+  function verifyAdding(media_type) {
+    var data = getLastProdStatus(media_type);
+    data.success(function(data) {
+        if(data['finish_date'] && (data['action_status'] == 3)) {
+          if(!media_type)
+            $('#addBraille').modal('show');
+          else
+            $('#add').modal('show');
+        }
+        else
+          $('#prod-notify').modal('show');
+      });
+  }
 
 function add(){
   //console.log($('#amount').val());
@@ -481,14 +512,10 @@ function confirmation(link) {
     $("#prod_media_type option[value='']").remove();
     enableProdText();
     hideProdNoti();
-    console.log('test add');
     $('#addProd').modal('show');
-    $.ajax({
-        type: "POST",
-        url: "/book/{{ $book['id'] }}/prod/get_status",
-        data: {book_id: {{ $book['id'] }}, media_type: media_type}
-      }).done(function(data) {
-        $('#prod_action option[value=' + (++data['action_status']) + ']').attr('selected', 'selected');
+    var data = getLastProdStatus(media_type);
+    data.success(function(data) {
+        $('#prod_action option[value=' + (++data['action_status']) + ']').attr('selected', 'true');
         $('#prod_action_text').val($('#prod_action option[value=' + data['action_status'] + ']').text());
         if(data['finish_date'] == null) {
           disableProdText();
@@ -501,6 +528,13 @@ function confirmation(link) {
       });
     });
 
+  function getLastProdStatus(media_type) {
+    return $.ajax({
+              type: "POST",
+              url: "/book/{{ $book['id'] }}/prod/get_status",
+              data: {book_id: {{ $book['id'] }}, media_type: media_type}
+            });
+  }
 
   function enableProdText() {
     $('#prod_actioner').removeAttr('disabled');
@@ -509,9 +543,9 @@ function confirmation(link) {
   }
 
   function disableProdText() {
-    $('#prod_actioner').prop('disabled', 'disabled');
-    $('#prod_act_date').prop('disabled', 'disabled');
-    $('#prod_finish_date').prop('disabled', 'disabled');
+    $('#prod_actioner').prop('disabled', 'false');
+    $('#prod_act_date').prop('disabled', 'false');
+    $('#prod_finish_date').prop('disabled', 'false');
   }
 
   function hideProdNoti() {
@@ -574,7 +608,7 @@ function confirmation(link) {
       $.post( "/book/{{ $book['id'] }}/prod/edit", {book_id:{{ $book['id'] }},prod_id: prodId, act_date:act_date, action:action,actioner:actioner,finish_date:finish_date}, function(result){
         // console.log(result);
         if(result=="success"){
-          $("#addProd").hide();
+          $("#prod-edit").hide();
           $('#success').modal('show');
         }else{
           $('#prod-edit-noti').slideDown(300);

--- a/app/views/library/book/view.blade.php
+++ b/app/views/library/book/view.blade.php
@@ -384,7 +384,6 @@ $('body').on('click', '#send-data', function() {
     $('#edit-detail').modal('hide');
   });
 });
-
 //Enable Link to tab
 
 
@@ -490,29 +489,33 @@ function confirmation(link) {
     }
 
     function prodEditShow(prodObj) {
-      $("#prod-edit").modal('show');
       // Append hidden field for prodId
-      console.log($(prodObj).children()[0]);
+      $('#prod_edit_action option[value=' + $(prodObj).children().eq(0).attr("data-action") + ']').attr('selected', 'selected');
+      $('#prod_edit_actioner').val($(prodObj).children().eq(1).attr("data-actioner"));
+      $('#prod_edit_act_date').val($(prodObj).children().eq(2).text().trim());
+      $('#prod_edit_finish_date').val($(prodObj).children().eq(3).text().trim());
       console.log($(prodObj).children()[1]);
       console.log($(prodObj).children()[2]);
-      $("#prod-edit-body").append('<input type="hidden" value="'+$(prodObj).attr("data-prodid")+'"'+'>')
-
+      console.log($(prodObj).children()[3]);
+      $("#prod_edit_id").val($(prodObj).attr("data-prodid"));
+      $("#prod-edit").modal('show');
     }
 
     function prodEditAjax(){
+      console.log('sending');
       var prodId = $('#prod_edit_id').val();
-      var media_type = $('#prod_edit_media_type').val();
+      console.log(prodId + " bookid {{ $book['id'] }}");
       var action = $('#prod_edit_action').val();
       var actioner = $('#prod_edit_actioner').val();
-      var act_date = $('#prod_edit_act_date').val();
-      var finish_date = $('#prod_edit_finish_date').val();
+      var act_date = ($('#prod_edit_act_date').val().trim() == "ยังไม่ได้ระบุ" ? null : $('#prod_edit_act_date').val());
+      var finish_date = ($('#prod_edit_finish_date').val().trim() == "ยังไม่ได้ระบุ" ? null : $('#prod_edit_finish_date').val());
 
       // console.log(act_date);
       // console.log(action);
       // console.log(actioner);
       // console.log(finish_date);
       
-      $.post( "/book/{{ $book['id'] }}/prod/edit", {book_id:{{ $book['id'] }},media_type:media_type,act_date:act_date, action:action,actioner:actioner,finish_date:finish_date}, function(result){
+      $.post( "/book/{{ $book['id'] }}/prod/edit", {book_id:{{ $book['id'] }},prod_id: prodId, act_date:act_date, action:action,actioner:actioner,finish_date:finish_date}, function(result){
         // console.log(result);
         if(result=="success"){
           $("#addProd").hide();

--- a/app/views/library/layout.blade.php
+++ b/app/views/library/layout.blade.php
@@ -8,6 +8,7 @@
 	<link href="{{ asset('css/bootstrap.min.css') }}" rel="stylesheet">
 	<!-- Main custom Bootstrap style -->
   <link rel="stylesheet" type="text/css" href=" {{ asset('css/main.css') }}">
+  <link rel="stylesheet" type="text/css" href=" {{ asset('css/font-awesome.css') }}">
 	<!-- date-picker style -->
   <link rel="stylesheet" type="text/css" href=" {{ asset('css/datepicker.css') }}">
 	<link rel="stylesheet" type="text/css" href="{{ asset('css/jquery.dataTables.min.css') }}">

--- a/app/views/library/media/braille.blade.php
+++ b/app/views/library/media/braille.blade.php
@@ -37,7 +37,7 @@
               <th class="col-md-1">ID</th>
 							<th class="col-md-1">ตอนที่</th>
 							<th class="col-md-2">สถานะ</th>
-							<th class="col-md-2">วันทีแก้ไข่</th>
+							<th class="col-md-2">วันทีแก้ไข</th>
 							<th>หมายเหตุ</th>
             </tr>
             @foreach ($detail as $key => $value)
@@ -63,7 +63,7 @@
         </div>
         <div class="col-md-12">
           <div class = "btn btn-warning pull-left" onclick="window.history.back()" > กลับ </div>
-          <input type = "submit"  class="btn btn-success pull-right" value = "แก้ไข">
+          <input type = "submit"  class="btn btn-success pull-right" value = "บันทึก">
         </div>
       </form>
     </div>

--- a/app/views/library/media/cassette.blade.php
+++ b/app/views/library/media/cassette.blade.php
@@ -35,9 +35,9 @@
 					<table class="table">
 						<tr>
 							<th class="col-md-1">ID</th>
-							<th class="col-md-1">ส่วนที่</th>
+							<th class="col-md-1">ตลับที่</th>
 							<th class="col-md-2">สถานะ</th>
-							<th class="col-md-2">วันที่</th>
+							<th class="col-md-2">วันที่แก้ไข</th>
 							<th>หมายเหตุ</th>
 						</tr>
 						@foreach ($detail as $key => $value)
@@ -63,7 +63,7 @@
 				</div>
 				<div class="col-md-12">
 					<div class = "btn btn-warning pull-left" onclick="window.history.back()" > กลับ </div>
-					<input type = "submit"  class="btn btn-success pull-right" value = "แก้ไข">
+					<input type = "submit"  class="btn btn-success pull-right" value = "บันทึก">
 				</div>
 			</form>
 		</div>

--- a/app/views/library/media/cd.blade.php
+++ b/app/views/library/media/cd.blade.php
@@ -36,7 +36,7 @@
 					<table class="table">
 						<tr>
 							<th class="col-md-1">ID</th>
-							<th class="col-md-1">ส่วนที่</th>
+							<th class="col-md-1">แผ่นที่</th>
 							<th class="col-md-1">สถานะ</th>
 							<th class="col-md-2">วันที่แก้ไข</th>
 							<th class="col-md-2">แทร็กเริ่มต้น</th>
@@ -72,7 +72,7 @@
 				</div>
 				<div class="col-md-12">
 					<div class = "btn btn-warning pull-left" onclick="window.history.back()" > กลับ </div>
-					<input type = "submit"  class="btn btn-success pull-right" value = "แก้ไข">
+					<input type = "submit"  class="btn btn-success pull-right" value = "บันทึก">
 				</div>
 			</form>
 		</div>

--- a/app/views/library/media/daisy.blade.php
+++ b/app/views/library/media/daisy.blade.php
@@ -36,7 +36,7 @@
 					<table class="table">
 						<tr>
 							<th class="col-md-1">ID</th>
-							<th class="col-md-1">ส่วนที่</th>
+							<th class="col-md-1">ชิ้นที่</th>
 							<th class="col-md-1">สถานะ</th>
 							<th class="col-md-2">วันที่แก้ไข</th>
 							<th class="col-md-2">แทร็กเริ่มต้น</th>
@@ -72,7 +72,7 @@
 				</div>
 				<div class="col-md-12">
 					<div class = "btn btn-warning pull-left" onclick="window.history.back()" > กลับ </div>
-					<input type = "submit"  class="btn btn-success pull-right" value = "แก้ไข">
+					<input type = "submit"  class="btn btn-success pull-right" value = "บันทึก">
 				</div>
 			</form>
 		</div>

--- a/app/views/library/media/dvd.blade.php
+++ b/app/views/library/media/dvd.blade.php
@@ -39,7 +39,7 @@
 					<table class="table">
 						<tr>
 							<th class="col-md-1">ID</th>
-							<th class="col-md-1">ตอนที่</th>
+							<th class="col-md-1">แผ่นที่</th>
 							<th class="col-md-2">สถานะ</th>
 							<th class="col-md-2">วันที่แก้ไข</th>
 							<th>หมายเหตุ</th>
@@ -67,7 +67,7 @@
 				</div>
 				<div class="col-md-12">
 					<div onclick="window.history.back()" class = "btn btn-warning pull-left"> กลับ </div>
-          <input type = "submit"  class="btn btn-success pull-right" value = "แก้ไข">
+          <input type = "submit"  class="btn btn-success pull-right" value = "บันทึก">
 				</div>
 			</form>
 		</div>

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -177,3 +177,7 @@ a {
   right: 0px;
   top: 50%;
 }
+
+.add-media-prod {
+  font-size: 16px;
+}


### PR DESCRIPTION
- added media-prod-add button to each media table.
  ![0](https://cloud.githubusercontent.com/assets/11440933/9631964/8532e18e-51ae-11e5-9e1d-55de7520ef80.JPG)
- added status-edit button to each row.
- added a delete button to latest added status, so the user can only delete the latest status of media production.
- braille table can only has 3 statuses follow by the below picture.
  ![1](https://cloud.githubusercontent.com/assets/11440933/9632289/7b735e10-51b0-11e5-8c60-1c2a29ec72af.JPG)
- tables of cassette, daisy, CD and DVD can only have 4 statuses follow by the below picture..
  ![2](https://cloud.githubusercontent.com/assets/11440933/9632379/09eec422-51b1-11e5-844d-8562a635b10a.JPG)
- automatically choose a production status when the user want to add an information.
  ![3](https://cloud.githubusercontent.com/assets/11440933/9632432/62d0b10e-51b1-11e5-864a-374d6181fffc.JPG)
- the user cannot add more status if the latest status is finally production or finished date is not filled.
  ![4](https://cloud.githubusercontent.com/assets/11440933/9632558/3a98c5f4-51b2-11e5-9dad-7163b6ec7445.JPG)
  ![9](https://cloud.githubusercontent.com/assets/11440933/9632623/8ba80da6-51b2-11e5-9cbb-3311dd8fbf86.JPG)
- the user cannot add any media until the finally production status with finished date is added to the table.
  ![5](https://cloud.githubusercontent.com/assets/11440933/9632673/c09bedca-51b2-11e5-86dd-8dd0d23dfde8.JPG)
- use appropriately words instead of original.
  ![6](https://cloud.githubusercontent.com/assets/11440933/9632756/4fcba422-51b3-11e5-8597-2ebdc0ca3812.JPG)
  ![7](https://cloud.githubusercontent.com/assets/11440933/9632757/4fcff374-51b3-11e5-83ca-2c46791fae20.JPG)
  ![8](https://cloud.githubusercontent.com/assets/11440933/9632758/4fd21852-51b3-11e5-8a83-9181baa80878.JPG)
